### PR TITLE
initial anaconda version 2.6.2

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,7 +1,5 @@
 {% set name = "cramjam" %}
 {% set version = "2.6.2" %}
-{% set py_ver_split = PY_VER.split(".") %}
-{% set major_minor = py_ver_split[ 0 ] + py_ver_split[ 1 ] %}
 
 package:
   name: {{ name|lower }}
@@ -13,34 +11,32 @@ source:
 
 build:
   number: 0
+  #skip s390x as it lack maturin dependency
+  skip: True # [s390x]
   script:
-    {% if build_platform != target_platform %}
-    - export PYO3_CROSS_INCLUDE_DIR=$PREFIX/include
-    - export PYO3_CROSS_LIB_DIR=$PREFIX/lib/python$PY_VER
-    - export PYO3_CROSS_PYTHON_VERSION=$PY_VER
-    {% endif %}
-    - {{ PYTHON }} -m pip install . -vv
+    - {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
 
 requirements:
   build:
-    - python                                 # [build_platform != target_platform]
-    - cross-python_{{ target_platform }}     # [build_platform != target_platform]
-    - maturin                                # [build_platform != target_platform]
-    - toml                                   # [build_platform != target_platform]
     - {{ compiler('rust') }}
     - {{ compiler('c') }}                    # [unix]
     - {{ compiler('m2w64_c') }}              # [win]
   host:
     - python
     - pip
-    - maturin
-    - toml
+    - setuptools
+    - wheel
+    - maturin 0.14.17
   run:
     - python
 
 test:
   imports:
     - cramjam
+  commands:
+    - pip check
+  requires:
+    - pip
 
 about:
   home: https://github.com/milesgranger/pyrus-cramjam
@@ -48,14 +44,14 @@ about:
   license_family: MIT
   license_file: LICENSE
   summary: python bindings to rust-implemented compression
-  # The remaining entries in this section are optional, but recommended.
   description: |
     Extremely thin Python bindings to de/compression algorithms in Rust. 
     Allows for using algorithms such as Snappy, without any system dependencies.
     This is handy when being used in environments like AWS Lambda, 
     where installing packages like python-snappy becomes difficult because of 
     system level dependencies.
-  doc_url: https://docs.rs/cramjam
+  dev_url: https://github.com/milesgranger/pyrus-cramjam
+  doc_url: https://docs.rs/cramjam/latest/cramjam/
 
 extra:
   recipe-maintainers:


### PR DESCRIPTION
initial anaconda commit of cramjam
- dependency for fastparquet 2023.4.0
- based on CF recipe https://github.com/AnacondaRecipes/cramjam-feedstock/blob/main/recipe/meta.yaml 
- skip s390x because of lack of maturin

